### PR TITLE
Added things to README.md that I would have liked to have had in there.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Additionally it installs,
 -   [linter-ui-default](https://atom.io/packages/linter-ui-default) which brings some UI additions for the linter
 -   [language-yaml](https://atom.io/packages/language-yaml) for all those `stack.yaml`s
 
-which you can optionally disable.
+any of which you can disable. If you don't like the way `atom-hasklig` alters
+fonts, uninstall it and clear the `Font Family` box in Settings (Preferences),
+under `Editor`.
 
 # Quick configuration
 
@@ -43,6 +45,10 @@ For formatters you have some choice between `stylish-haskell`, `hindent` and `br
 ```bash
 stack install hindent
 ```
+
+Follow this up with:  
+Edit -> Preferences -> Packages -> atom-beautify -> Settings -> Haskell ->
+*expand* -> *[your choice of beautifier]*
 
 # Other things
 


### PR DESCRIPTION
* Did not like how `atom-haskligs` alters fonts, especially when editing
Markdown. It took me a while to figure out how to put things back. README.md
now tells the reader how to do so.

* README.md was missing the follow-up to installing the beautifier: setting it.
It now has that instruction.